### PR TITLE
fix(semantic release): add branches for main

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,5 +9,6 @@
                 "publishCmd": "bash deploy.sh"
             }
         ]
-    ]
+    ],
+    "branches": ["main"]
 }


### PR DESCRIPTION
By default it looks for the `master` branch which is our default for almost all the other `ladybug-tools` repositories.