### PR TITLE
fix: catch assertion errors for the solving adjacency

### DIFF
--- a/honeybee_doe2/writer.py
+++ b/honeybee_doe2/writer.py
@@ -26,9 +26,18 @@ def model_to_inp(hb_model):
     if hb_model.units != 'Feet':
         hb_model.convert_to_units(units='Feet')
     hb_model.remove_degenerate_geometry()
-    hb_model.rectangularize_apertures(
-        subdivision_distance=0.5, max_separation=0.0, merge_all=True
-    )
+
+    try:
+        hb_model.rectangularize_apertures(
+            subdivision_distance=0.5, max_separation=0.0, merge_all=True,
+            resolve_adjacency=True
+        )
+    except AssertionError:
+        # try without resolving adjacency that can create errors
+        hb_model.rectangularize_apertures(
+            subdivision_distance=0.5, max_separation=0.0, merge_all=True,
+            resolve_adjacency=False
+        )
 
     room_names = {}
     face_names = {}


### PR DESCRIPTION
Solve adjacency is a nice-to-have feature but let's make sure it doesn't break the whole translation because the apertures don't match between two faces. This is something that the user can fix later.