### PR TITLE
fix(cli): improve hvac mapping implementation

### DIFF
--- a/honeybee_doe2/cli/translate.py
+++ b/honeybee_doe2/cli/translate.py
@@ -19,10 +19,12 @@ def translate():
 @click.argument('hb-json', type=click.Path(
     exists=True, file_okay=True, dir_okay=False, resolve_path=True)
 )
-@click.option('--hvac_mapping', '-hg',
-              help='HVAC mapping method, room, story or model', default='story',
-              show_default=True)
-@click.option('--name', '-n', help='Name of the output file.', default="model",
+@click.option(
+    '--hvac-mapping', '-hm', help='HVAC mapping method. Options are room, story, model '
+    'or assigned-hvac.',
+    default='story', show_default=True, type=click.Choice(
+    ['room', 'story', 'model', 'assigned-hvac'], case_sensitive=False))
+@click.option('--name', '-n', help='Name of the output file.', default='model',
               show_default=True
               )
 @click.option('--folder', '-f', help='Path to target folder.', type=click.Path(

--- a/honeybee_doe2/writer.py
+++ b/honeybee_doe2/writer.py
@@ -20,10 +20,10 @@ def model_to_inp(hb_model, hvac_mapping='story'):
     """
         args:
             hb_model: Honeybee model
-            hvac_mapping: accepts: 'room', 'story', 'model', 'hb_hvac'
+            hvac_mapping: accepts: 'room', 'story', 'model', 'assigned-hvac'
     """
 
-    mapper_options = ['room', 'story', 'model', 'hb_hvac']
+    mapper_options = ['room', 'story', 'model', 'assigned-hvac']
     if hvac_mapping not in mapper_options:
         raise ValueError(
             f'Invalid hvac_mapping input: {hvac_mapping}\n'
@@ -36,7 +36,7 @@ def model_to_inp(hb_model, hvac_mapping='story'):
         hvac_maps = hb_model.properties.doe2.hvac_sys_zones_by_story
     elif hvac_mapping == 'model':
         hvac_maps = hb_model.properties.doe2.hvac_sys_zones_by_model
-    elif hvac_mapping == 'hb_hvac':
+    elif hvac_mapping == 'assigned-hvac':
         hvac_maps = hb_model.properties.doe2.hvac_sys_zones_by_hb_hvac
 
     rp = RunPeriod()

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -15,7 +15,7 @@ def test_model_to_folder():
 
     result = runner.invoke(
         hb_model_to_inp_file,
-        [input_hb_model, '--hvac_mapping', hvac_mapping, '--name', name, '--folder', folder])
+        [input_hb_model, '--hvac-mapping', hvac_mapping, '--name', name, '--folder', folder])
 
     assert result.exit_code == 0
     assert os.path.isfile(os.path.join(folder, f'{name}.inp'))


### PR DESCRIPTION
1. Make naming consistent. `--hvac-mapping`, and `-hm`
2. Use `assigned-hvac` instead of `hb-hvac`
