### PR TITLE
feat: added multiplier to type limits

### DIFF
--- a/honeybee_doe2/schedule.py
+++ b/honeybee_doe2/schedule.py
@@ -23,7 +23,7 @@ def schedule_type_limit_to_inp(type_limit):
     """Get the DOE-2 type for a honeybee-energy ScheduleTypeLimit."""
     if type_limit is None:
         return 'FRACTION'
-    elif type_limit  == 'Multiplier':
+    elif type_limit.display_name  == 'Multiplier':
         return "MULTIPLIER"
     elif type_limit.unit_type == 'Temperature':
         return 'TEMPERATURE'

--- a/honeybee_doe2/schedule.py
+++ b/honeybee_doe2/schedule.py
@@ -23,6 +23,8 @@ def schedule_type_limit_to_inp(type_limit):
     """Get the DOE-2 type for a honeybee-energy ScheduleTypeLimit."""
     if type_limit is None:
         return 'FRACTION'
+    elif type_limit  == 'Multiplier':
+        return "MULTIPLIER"
     elif type_limit.unit_type == 'Temperature':
         return 'TEMPERATURE'
     else:


### PR DESCRIPTION
This PR adds an additional type limit to the ```def schedule_type_limit_to_inp``` to allow for MULTIPLIER type limits to pass