### PR TITLE
fix(writer): Ensure that duplicate day schedule ids are impossible

### DIFF
--- a/honeybee_doe2/config.py
+++ b/honeybee_doe2/config.py
@@ -4,7 +4,7 @@
 DOE2_TOLERANCE = 0.03  # current best guess for DOE-2 absolute tolerance in Feet
 DOE2_ANGLE_TOL = 1.0  # current best guess for DOE-2 angle tolerance in degrees
 FLOOR_LEVEL_TOL = 0.1  # tolerance for grouping Rooms by floor elevations in Feet
-GEO_DEC_COUNT = 3  # number of decimal places that all geometry will be rounded
+GEO_DEC_COUNT = 4  # number of decimal places that all geometry will be rounded
 RECT_WIN_SUBD = 0.5  # subdivision distance to rectangularize windows in Feet
 DOE2_INTERIOR_BCS = ('Surface', 'Adiabatic', 'OtherSideTemperature')
 MIN_LAYER_THICKNESS = 0.003  # the minimum thickness for a material to be valid in meters

--- a/honeybee_doe2/writer.py
+++ b/honeybee_doe2/writer.py
@@ -776,10 +776,11 @@ def model_to_inp(
             # check that day schedules aren't referenced by other model schedules
             day_scheds = []
             for day in sched.day_schedules:
-                if day.identifier not in used_day_sched_ids:
+                sch_doe2_id = clean_doe2_string(day.identifier, RES_CHARS)
+                if sch_doe2_id not in used_day_sched_ids:
                     day_scheds.append(day.to_inp(sched.schedule_type_limit))
-                    used_day_sched_ids[day.identifier] = day
-                elif day != used_day_sched_ids[day.identifier]:
+                    used_day_sched_ids[sch_doe2_id] = day
+                elif day != used_day_sched_ids[sch_doe2_id]:
                     new_day = day.duplicate()
                     new_day.identifier = 'Schedule Day {}'.format(used_day_count)
                     day_scheds.append(new_day.to_inp(sched.schedule_type_limit))


### PR DESCRIPTION
I am also changing the number of decimals that we round the geometry to 4 instead of 3 as this was needed to ensure compatibility with the native DOE-2 tolerance that we assume. Four decimals should be enough to ensure that users never encounter the "Duplicate Vertices Error" that DOE-2 will give if vertices are rounded off to be the same value.