### PR TITLE
fix(style): Fix many PEP8 styling issues

### DIFF
--- a/honeybee_doe2/reader.py
+++ b/honeybee_doe2/reader.py
@@ -1,29 +1,131 @@
+# coding=utf-8
 """Methods to read inp files to Honeybee."""
 from __future__ import division
+
 import os
 import math
 import re
 from collections import defaultdict
+
 from ladybug_geometry.geometry3d import Point3D, Vector3D, Face3D
 from honeybee.model import Model
-from honeybee.facetype import Wall, RoofCeiling, Floor    
+from honeybee.facetype import Wall, RoofCeiling, Floor
 from honeybee.room import Room
 from honeybee.face import Face
 from honeybee.aperture import Aperture
-from honeybee.door import Door 
+from honeybee.door import Door
 from honeybee_energy.boundarycondition import Adiabatic
 from honeybee.boundarycondition import Outdoors, Ground
 from honeybee.typing import clean_string
 
-from .config import DOE2_ANGLE_TOL, GEO_DEC_COUNT, DOE2_TOLERANCE
+from .config import DOE2_ANGLE_TOL, DOE2_TOLERANCE
 from .util import clean_inp_file_contents, doe2_object_blocks, parse_inp_string
 
-_CMD_TO_BC      = {
-                    "EXTERIOR-WALL":   Outdoors,
-                    "INTERIOR-WALL":   Adiabatic,
-                    "UNDERGROUND-WALL": Ground,
-                    "ROOF":            Outdoors,  
+_CMD_TO_BC = {
+    'EXTERIOR-WALL':   Outdoors,
+    'INTERIOR-WALL':   Adiabatic,
+    'UNDERGROUND-WALL': Ground,
+    'ROOF':            Outdoors,
 }
+
+
+def model_from_inp_file(inp_file):
+    """Convert an inp file to an HBJSON Model object
+
+    Args:
+        inp_file: A text string for the path to an INP file.
+
+    Returns:
+        A honeybee Model object.
+    """
+    assert os.path.isfile(inp_file), 'No file was found at: {}'.format(inp_file)
+    with open(inp_file, 'r') as doe_file:
+        inp_content = doe_file.read()
+    return model_from_inp(inp_content)
+
+
+def model_from_inp(inp_file_contents):
+    """Convert an inp file to an HBJSON Model object
+
+    Args:
+        inp_file_contents: A text string of the complete contents of an INP file.
+
+    Returns:
+        A honeybee Model object.
+    """
+    cmd_dict = command_dict_from_inp(inp_file_contents)
+    floors = cmd_dict.get("FLOOR", {})
+    polys = cmd_dict.get("POLYGON", {})
+    glob_az = -float(cmd_dict.get("BUILD-PARAMETERS", {}).get("AZIMUTH", 0) or 0)
+
+    if not floors:
+        raise ValueError("No FLOOR objects found in INP - nothing to translate.")
+
+    rooms = []
+
+    for flr_name, flr in floors.items():
+        fx, fy, fz, flr_az = _origin_and_azimuth(flr, None, False)
+        flr_origin = Point3D(fx, fy, fz)
+        floor_poly = (flr.get("POLYGON") or "").strip('"')
+        floor_verts = _verts_to_tuples(polys.get(floor_poly, {}))
+        flr_mult = (flr.get("MULTIPLIER") or 1.0)
+
+        spaces = _child_objects_from_parent(cmd_dict, flr_name, "FLOOR", "SPACE")
+        for spc_name, spc in spaces.items():
+            shape = (spc.get("SHAPE") or "").upper()
+            if not shape or shape == "NO-SHAPE":
+                continue
+            if shape == "BOX":
+                # TODO: Support translation of BOX SHAPE SPACE objects.
+                # Need to find or create INP example file for this
+                msg = '{} is defined by a BOX - convert to POLYGON.'.format(spc_name)
+                raise ValueError(msg)
+
+            # Local footprint
+            plg = spc.get("POLYGON", "").strip('"')
+            spc_verts_local = _verts_to_tuples(polys.get(plg, {}))
+            if not spc_verts_local:
+                continue
+            spc_pts_local = [Point3D(x, y, 0) for x, y in spc_verts_local]
+
+            # Space transform
+            sx, sy, sz, spc_az = _origin_and_azimuth(spc, floor_verts, False)
+            spc_pts_global = _transform_space_points(
+                spc_pts_local, Point3D(sx, sy, sz), spc_az,
+                flr_origin, flr_az,
+                glob_az
+            )
+
+            walls = _surfaces_from_space(cmd_dict, spc_name)
+            detailed = walls and all(w.get("POLYGON") for w in walls.values())
+            # for now, we only use detailed translator if all walls are POLYGON shape
+            # TODO: support preservation of all face geometry when only some are POLYGON
+            if detailed:
+                faces = _volume_from_polygons(
+                    cmd_dict,
+                    walls,
+                    polys,
+                    spc_pts_global, spc_pts_local, spc_name,
+                    flr_origin, flr_az, glob_az,
+                )
+            else:
+                edge_info, floor_bc, ceiling_bc = \
+                    _edge_info_map(cmd_dict, walls, spc_pts_global, spc_pts_local)
+                faces = _extruded_shell(spc, spc_pts_global, edge_info,
+                                        floor_bc, ceiling_bc, spc_name, flr)
+
+            room = Room(identifier=clean_string(spc_name), faces=faces)
+            room.display_name = spc_name
+            room.story = flr_name
+            room.multiplier = flr_mult
+            rooms.append(room)
+
+    model_name = cmd_dict.get('TITLE', {}).get('LINE-1', 'Model From DOE2')
+    model_name = model_name.replace('*', '')
+
+    return Model(clean_string(model_name), rooms, units='Feet',
+                 tolerance=DOE2_TOLERANCE, angle_tolerance=DOE2_ANGLE_TOL)
+
 
 def command_dict_from_inp(inp_file_contents):
     """Get a dictionary of INP commands and U-names from a INP file content string.
@@ -48,15 +150,15 @@ def command_dict_from_inp(inp_file_contents):
     # Get globals and TITLE first since they are formatted slightly differently
     for blk in blocks:
         u_name, cmd, keys, vals = parse_inp_string(blk)
-        if cmd == "PARAMETER":
+        if cmd == 'PARAMETER':
             key, val_raw = keys[0], vals[0]
             try:
                 global_parameters[key] = float(val_raw)
             except ValueError:
                 global_parameters[key] = val_raw
-        elif cmd == "TITLE":
+        elif cmd == 'TITLE':
             key, val = keys[0], vals[0]
-            result["TITLE"][key] = val
+            result['TITLE'][key] = val
         else:
             cmd_blocks.append(blk)
 
@@ -72,95 +174,23 @@ def command_dict_from_inp(inp_file_contents):
                 attr_d[k] = float(v)
             except ValueError:
                 attr_d[k] = v
-        attr_d["__line__"] = block_line_count
-        attr_d["cmd"] = cmd 
+        attr_d['__line__'] = block_line_count
+        attr_d['cmd'] = cmd
         block_line_count += 1
         result[cmd][u_name] = attr_d
 
     if global_parameters:
-        result["PARAMETER"] = global_parameters
+        result['PARAMETER'] = global_parameters
 
     return dict(result)
 
-def model_from_inp(inp_file_contents):
-    """Convert an inp file to an HBJSON Model object
 
-    Args:
-        inp_file_contents: A text string of the complete contents of an INP file.
-
-    Returns:
-        A honeybee Model object. This only converts the geometry 
-
-    """
-    cmd_dict = command_dict_from_inp(inp_file_contents)
-    floors = cmd_dict.get("FLOOR", {})
-    polys  = cmd_dict.get("POLYGON", {})
-    glob_az = -float(cmd_dict.get("BUILD-PARAMETERS", {}).get("AZIMUTH", 0) or 0)
-
-    if not floors:
-        raise ValueError("No FLOOR objects found in INP – nothing to translate.")
-
-    rooms = []
-
-    for flr_name, flr in floors.items():
-        fx, fy, fz, flr_az = _origin_and_azimuth(flr, None, False)
-        flr_origin = Point3D(fx, fy, fz)
-        floor_poly = (flr.get("POLYGON") or "").strip('"')
-        floor_verts = _verts_to_tuples(polys.get(floor_poly, {}))
-        flr_mult = (flr.get("MULTIPLIER") or 1.0)
-
-        spaces = child_objects_from_parent(cmd_dict, flr_name, "FLOOR", "SPACE")
-        for spc_name, spc in spaces.items():
-            shape = (spc.get("SHAPE") or "").upper()
-            if not shape or shape == "NO-SHAPE":
-                continue
-            if shape == "BOX":
-                # TODO: Support BOX SHAPE SPACE objects... Need to find or create INP example file
-                raise ValueError(f"{spc_name} is defined by a BOX – convert to POLYGON first.")
-
-            # Local footprint
-            plg = spc.get("POLYGON", "").strip('"')
-            spc_verts_local = _verts_to_tuples(polys.get(plg, {}))
-            if not spc_verts_local:
-                continue
-            spc_pts_local = [Point3D(x, y, 0) for x, y in spc_verts_local]
-
-            # Space transform
-            sx, sy, sz, spc_az = _origin_and_azimuth(spc, floor_verts, False)
-            spc_pts_global = _transform_space_points(
-                spc_pts_local, Point3D(sx, sy, sz), spc_az,
-                flr_origin, flr_az,
-                glob_az
-            )
-
-            walls = surfaces_from_space(cmd_dict, spc_name)
-            detailed = walls and all(w.get("POLYGON") for w in walls.values()) # If all walls are POLYGON shape
-            if detailed:
-                faces = _volume_from_polygons(
-                    cmd_dict,
-                    walls, 
-                    polys,
-                    spc_pts_global, spc_pts_local, spc_name, 
-                    flr_origin, flr_az, glob_az,  
-                )
-            else:
-                # TODO: Support the ability to preserve the original face geometry
-                edge_info, floor_bc, ceiling_bc  = _edge_info_map(cmd_dict, walls, spc_pts_global, spc_pts_local)
-                faces = _extruded_shell(spc, spc_pts_global, edge_info, floor_bc, ceiling_bc, spc_name, flr)
-
-            room = Room(identifier=clean_string(spc_name), faces=faces)
-            room.display_name = spc_name
-            room.story = flr_name
-            room.multiplier = flr_mult
-            rooms.append(room)
-
-    model_name = cmd_dict.get("TITLE", {}).get("LINE-1", "Model From DOE2").replace("*","")
-    
-    return Model(clean_string(model_name), rooms, units='Feet', tolerance=DOE2_TOLERANCE, angle_tolerance=DOE2_ANGLE_TOL)
-
-def _volume_from_polygons(cmd_dict, walls, polys, spc_pts_global, spc_pts_local, spc_name, flr_origin, flr_az, glob_az):
+def _volume_from_polygons(
+    cmd_dict, walls, polys, spc_pts_global, spc_pts_local, spc_name,
+    flr_origin, flr_az, glob_az
+):
     """Build detailed faces when each wall has its own POLYGON.
-    
+
     Args:
         cmd_dict: Command dictionary containing all DOE2 objects.
         walls: Dictionary of wall objects and their attributes.
@@ -171,7 +201,7 @@ def _volume_from_polygons(cmd_dict, walls, polys, spc_pts_global, spc_pts_local,
         flr_origin: Point3D object representing the floor origin.
         flr_az: Floor azimuth angle in degrees.
         glob_az: Global azimuth angle in degrees.
-     
+
     Returns:
         list[Face]: A list of honeybee Face objects representing the space geometry,
         including walls, floor, and ceiling with their respective apertures and doors.
@@ -182,12 +212,12 @@ def _volume_from_polygons(cmd_dict, walls, polys, spc_pts_global, spc_pts_local,
     base_z = spc_pts_global[0].z if spc_pts_global else 0
 
     for w_name, w_attrs in walls.items():
-        plg = (w_attrs.get("POLYGON") or "").strip('"')
+        plg = (w_attrs.get('POLYGON') or '').strip('"')
         verts_local = _verts_to_tuples(polys.get(plg, {}))
         if not verts_local:
             continue
 
-        wx, wy, wz, wall_az  = _origin_and_azimuth(w_attrs, spc_pts_local, True)
+        wx, wy, wz, wall_az = _origin_and_azimuth(w_attrs, spc_pts_local, True)
         tilt = _get_wall_tilt(w_attrs)
 
         pts = [Point3D(x, y, 0) for x, y in verts_local]
@@ -206,11 +236,11 @@ def _volume_from_polygons(cmd_dict, walls, polys, spc_pts_global, spc_pts_local,
             glob_az
         )
 
-        cmd = w_attrs.get("cmd")
+        cmd = w_attrs.get('cmd')
         try:
-            bc = _CMD_TO_BC[cmd]()     
+            bc = _CMD_TO_BC[cmd]()
         except KeyError:
-            raise ValueError(f"Unknown DOE2 surface command: {cmd!r}")
+            raise ValueError('Unknown DOE2 surface command: {}'.format(cmd))
 
         t = abs(tilt % 360)
         if t > 180 - DOE2_ANGLE_TOL:
@@ -224,16 +254,16 @@ def _volume_from_polygons(cmd_dict, walls, polys, spc_pts_global, spc_pts_local,
                 ftype = RoofCeiling()
 
         face = Face(
-            identifier=f"{clean_string(spc_name)}_Face_{idx}",
+            identifier='{}_Face_{}'.format(clean_string(spc_name), idx),
             geometry=Face3D([Point3D(p.x, p.y, p.z) for p in pts_global]),
             type=ftype,
             boundary_condition=bc
         )
-        #If an exterior wall check for doors and aperatures
-        if cmd == "EXTERIOR-WALL" and len(pts_global) >= 2:
+        # if an exterior wall check for doors and apertures
+        if cmd == 'EXTERIOR-WALL' and len(pts_global) >= 2:
             gp1, gp2 = pts_global[0], pts_global[1]
             apps = _apertures_from_wall(cmd_dict, w_name, idx, gp1, gp2, base_z)
-            drs  = _doors_from_wall(cmd_dict, w_name, idx, gp1, gp2, base_z)
+            drs = _doors_from_wall(cmd_dict, w_name, idx, gp1, gp2, base_z)
             if apps:
                 face.add_apertures(apps)
             if drs:
@@ -244,26 +274,30 @@ def _volume_from_polygons(cmd_dict, walls, polys, spc_pts_global, spc_pts_local,
 
     return faces
 
+
 class _EdgeInfo:
-    __slots__ = ("bc", "apertures", "doors")
+    """Class for storing information about wall edges."""
+    __slots__ = ('bc', 'apertures', 'doors')
+
     def __init__(self):
-        self.bc    = Outdoors() 
-        self.apertures  = []
+        self.bc = Outdoors()
+        self.apertures = []
         self.doors = []
 
-def _edge_info_map(cmd_dict, walls_dict, spc_verts_global, spc_verts_local):  
-    """Creates a dictionary mapping each vertex index to its corresponding EdgeInfo object.
-    
+
+def _edge_info_map(cmd_dict, walls_dict, spc_verts_global, spc_verts_local):
+    """Create a dict mapping each vertex index to its corresponding EdgeInfo object.
+
     Args:
         cmd_dict: Command dictionary containing all DOE2 objects.
         walls_dict: Dictionary of walls with their attributes, keyed by wall u_name.
         spc_verts_global: List of global space vertices that define the space footprint.
         spc_verts_local: List of local space vertices that define the space footprint.
-        
+
     Returns:
         tuple[dict[int, _EdgeInfo], BoundaryCondition, BoundaryCondition]:
-            - edge_info: mapping from vertex index to its _EdgeInfo (with bc, apertures, doors)
-            - floor_bc: The floor BoundaryCondition 
+            - edge_info: map from vertex index to _EdgeInfo (with bc, apertures, doors)
+            - floor_bc: The floor BoundaryCondition
             - ceiling_bc: The ceiling/roof BoundaryCondition
 
     """
@@ -272,52 +306,53 @@ def _edge_info_map(cmd_dict, walls_dict, spc_verts_global, spc_verts_local):
     ceiling_bc = Outdoors()
 
     for w_name, w_attrs in walls_dict.items():
-
         tilt = _get_wall_tilt(w_attrs)
 
         if tilt == 90:
-            start, idx = _wall_start_point(w_attrs, spc_verts_local)
-
+            _, idx = _wall_start_point(w_attrs, spc_verts_local)
             if idx < 0:
                 continue
-    
-            cmd = w_attrs.get("cmd")
+            cmd = w_attrs.get('cmd')
             try:
-                info[idx].bc = _CMD_TO_BC[cmd]()     
+                info[idx].bc = _CMD_TO_BC[cmd]()
             except KeyError:
-                raise ValueError(f"Unknown DOE2 surface command: {cmd!r}")
+                raise ValueError('Unknown DOE2 surface command: {}'.format(cmd))
 
             p1 = spc_verts_global[idx]
-            p2 = spc_verts_global[0] if idx == len(spc_verts_global) - 1 else spc_verts_global[idx + 1]
+            p2 = spc_verts_global[0] if idx == len(spc_verts_global) - 1 else \
+                spc_verts_global[idx + 1]
             base_z = p1.z
-            
-            info[idx].apertures = _apertures_from_wall(cmd_dict, w_name, idx, p1, p2, base_z)
-            info[idx].doors     = _doors_from_wall(cmd_dict, w_name, idx, p1, p2, base_z)
+
+            info[idx].apertures = \
+                _apertures_from_wall(cmd_dict, w_name, idx, p1, p2, base_z)
+            info[idx].doors = \
+                _doors_from_wall(cmd_dict, w_name, idx, p1, p2, base_z)
         else:
-            loc = w_attrs.get("LOCATION", "")
-            cmd = w_attrs.get("cmd")
-            if loc == "TOP":
+            loc = w_attrs.get('LOCATION', '')
+            cmd = w_attrs.get('cmd')
+            if loc == 'TOP':
                 ceiling_bc = _CMD_TO_BC[cmd]()
-            elif loc == "BOTTOM":
+            elif loc == 'BOTTOM':
                 floor_bc = _CMD_TO_BC[cmd]()
             else:
                 pass
-    
+
     return info, floor_bc, ceiling_bc
 
 
-def _extruded_shell(spc_attrs, verts_glob, edge_info, floor_bc, ceiling_bc, spc_name, flr_attrs):
+def _extruded_shell(spc_attrs, verts_glob, edge_info, floor_bc, ceiling_bc,
+                    spc_name, flr_attrs):
     """Creates a list of honeybee Face objects representing the space shell geometry.
-    
+
     Args:
         spc_attrs: Dictionary of space attributes.
         verts_glob: List of transformed vertices defining the space footprint.
         edge_info: Dictionary mapping vertex indices to corresponding EdgeInfo instances.
-        floor_bc: The floor BoundaryCondition 
-        ceiling_bc: The ceiling/roof BoundaryCondition
+        floor_bc: The floor BoundaryCondition.
+        ceiling_bc: The ceiling/roof BoundaryCondition.
         spc_name: Name of the current space.
         flr_attrs: Dictionary of floor attributes.
-        
+
     Returns:
         list[Face]: A list of Face instances representing the complete space shell
     """
@@ -329,10 +364,10 @@ def _extruded_shell(spc_attrs, verts_glob, edge_info, floor_bc, ceiling_bc, spc_
     floor_pts = [Point3D(p.x, p.y, p.z) for p in verts_glob]
     faces.append(
         Face(
-            identifier= f"{clean_string(spc_name)}_Floor",
-            geometry= Face3D(floor_pts),
-            type=Floor(),  
-            boundary_condition= floor_bc
+            identifier='{}_Floor'.format(clean_string(spc_name)),
+            geometry=Face3D(floor_pts),
+            type=Floor(),
+            boundary_condition=floor_bc
         )
     )
 
@@ -340,10 +375,10 @@ def _extruded_shell(spc_attrs, verts_glob, edge_info, floor_bc, ceiling_bc, spc_
     ceil_pts = [Point3D(p.x, p.y, p.z + height) for p in verts_glob]
     faces.append(
         Face(
-            identifier= f"{clean_string(spc_name)}_Ceiling",
-            geometry= Face3D(ceil_pts),
-            type = RoofCeiling(), 
-            boundary_condition= ceiling_bc
+            identifier='{}_Ceiling'.format(clean_string(spc_name)),
+            geometry=Face3D(ceil_pts),
+            type=RoofCeiling(),
+            boundary_condition=ceiling_bc
         )
     )
 
@@ -357,36 +392,37 @@ def _extruded_shell(spc_attrs, verts_glob, edge_info, floor_bc, ceiling_bc, spc_
             Point3D(p2.x, p2.y, p2.z + height),
             Point3D(p1.x, p1.y, p1.z + height),
         ]
-    
+
         face = Face(
-            identifier=f"{clean_string(spc_name)}_Wall_{i + 1}",
+            identifier='{}_Wall_{}'.format(clean_string(spc_name), i + 1),
             geometry=Face3D(wall_pts),
-            type= Wall(), 
-            boundary_condition = edge_info[i].bc
+            type=Wall(),
+            boundary_condition=edge_info[i].bc
         )
         if edge_info[i].apertures:
-            face.add_apertures(edge_info[i].apertures) 
+            face.add_apertures(edge_info[i].apertures)
         if edge_info[i].doors:
-            face.add_doors(edge_info[i].doors) 
+            face.add_doors(edge_info[i].doors)
         faces.append(face)
     return faces
 
+
 def _wall_start_point(wall_attrs, spc_verts_local):
     """Find the starting point and vertex index for a wall in global coordinates.
-    
+
     Args:
         wall_attrs: Dictionary of wall attributes.
         spc_verts_local: List of local space vertices.
-        
+
     Returns:
         tuple[float, float], int: A tuple containing:
             - The (x, y) coordinates of the wall's starting point
             - The index of the matching vertex in the spaces local coordinates
     """
-    loc = wall_attrs.get("LOCATION", "")
+    loc = wall_attrs.get('LOCATION', '')
     count = len(spc_verts_local)
-    if loc.upper().startswith("SPACE-V"):
-        n = int(loc.split("SPACE-V")[1])
+    if loc.upper().startswith('SPACE-V'):
+        n = int(loc.split('SPACE-V')[1])
         if 1 <= n <= count:
             v = spc_verts_local[n - 1]
             return (v.x, v.y), n - 1
@@ -397,9 +433,10 @@ def _wall_start_point(wall_attrs, spc_verts_local):
             return (v.x, v.y), i
     return None, -1
 
+
 def _apertures_from_wall(cmd_dict, w_name, idx, gp1, gp2, z0):
     """Create aperture objects for windows in a wall.
-    
+
     Args:
         cmd_dict: Command dictionary containing all DOE2 objects.
         w_name: Name of the parent wall.
@@ -407,7 +444,7 @@ def _apertures_from_wall(cmd_dict, w_name, idx, gp1, gp2, z0):
         gp1: Point3D representing wall's start point.
         gp2: Point3D representing wall's end point.
         z0: Base height of the wall.
-        
+
     Returns:
         list[Aperture]: List of Aperture objects for the wall
     """
@@ -418,17 +455,17 @@ def _apertures_from_wall(cmd_dict, w_name, idx, gp1, gp2, z0):
         return apps
     ux, uy = dx / length, dy / length
 
-    wins = child_objects_from_parent(cmd_dict, w_name, "EXTERIOR-WALL", "WINDOW")
+    wins = _child_objects_from_parent(cmd_dict, w_name, 'EXTERIOR-WALL', 'WINDOW')
     n = 1
     for win in wins.values():
-        w  = float(win.get("WIDTH", 0) or 0)
-        h  = float(win.get("HEIGHT", 0) or 0)
-        xo = float(win.get("X", 0) or 0)
-        yo = float(win.get("Y", 0) or 0)
+        w = float(win.get('WIDTH', 0) or 0)
+        h = float(win.get('HEIGHT', 0) or 0)
+        xo = float(win.get('X', 0) or 0)
+        yo = float(win.get('Y', 0) or 0)
         pts = _build_subface_corners((gp1.x, gp1.y), ux, uy, xo, yo, w, h, z0)
         apps.append(
             Aperture(
-                f"{clean_string(w_name)}_Win{idx}_{n}",
+                '{}_Win{}_{}'.format(clean_string(w_name), idx, n),
                 Face3D(pts),
                 boundary_condition=Outdoors(),
             )
@@ -436,9 +473,10 @@ def _apertures_from_wall(cmd_dict, w_name, idx, gp1, gp2, z0):
         n += 1
     return apps
 
+
 def _doors_from_wall(cmd_dict, w_name, idx, gp1, gp2, z0):
     """Create door objects for a wall.
-    
+
     Args:
         cmd_dict: Command dictionary containing all DOE2 objects.
         w_name: Name of the parent wall.
@@ -446,7 +484,7 @@ def _doors_from_wall(cmd_dict, w_name, idx, gp1, gp2, z0):
         gp1: Point3D representing wall's start point.
         gp2: Point3D representing wall's end point.
         z0: Base height of the wall.
-        
+
     Returns:
         list[Door]: List of Door objects for the wall.
     """
@@ -457,39 +495,41 @@ def _doors_from_wall(cmd_dict, w_name, idx, gp1, gp2, z0):
         return doors
     ux, uy = dx / length, dy / length
 
-    drs = child_objects_from_parent(cmd_dict, w_name, "EXTERIOR-WALL", "DOOR")
+    drs = _child_objects_from_parent(cmd_dict, w_name, 'EXTERIOR-WALL', 'DOOR')
     n = 1
     for d in drs.values():
-        w  = float(d.get("WIDTH", 3.0) or 3.0)
-        h  = float(d.get("HEIGHT", 7.0) or 7.0)
+        w = float(d.get('WIDTH', 3.0) or 3.0)
+        h = float(d.get('HEIGHT', 7.0) or 7.0)
         xo = float(d.get("X", 0) or 0)
         yo = float(d.get("Y", 0) or 0)
         pts = _build_subface_corners((gp1.x, gp1.y), ux, uy, xo, yo, w, h, z0)
         doors.append(
             Door(
-                f"{clean_string(w_name)}_Door{idx}_{n}",
+                '{}_Door{}_{}'.format(clean_string(w_name), idx, n),
                 Face3D(pts),
-                boundary_condition= Outdoors(),
+                boundary_condition=Outdoors(),
             )
         )
         n += 1
     return doors
 
+
 def _get_origin(attrs):
     """Return (x, y, z) coordinates from a DOE-2 object dict.
-    
+
     Args:
         attrs: Dictionary containing DOE2 object attributes.
-        
+
     Returns:
         tuple[float, float, float]: The (x, y, z) coordinates, defaulting to 0
         for any missing values.
     """
     return (
-        float(attrs.get("X", 0) or 0),
-        float(attrs.get("Y", 0) or 0),
-        float(attrs.get("Z", 0) or 0),
+        float(attrs.get('X', 0) or 0),
+        float(attrs.get('Y', 0) or 0),
+        float(attrs.get('Z', 0) or 0),
     )
+
 
 def _transform_points(pts, az_deg, origin_vec):
     """Rotate points about Z axis and then translate them.
@@ -510,6 +550,7 @@ def _transform_points(pts, az_deg, origin_vec):
         out.append(p.rotate_xy(angle, Point3D(0, 0, 0)).move(move_vec))
     return out
 
+
 def _build_subface_corners(origin, ux, uy, offx, offy, width, height, z0):
     """Generate the four corner Point3D objects of a rectangular sub-surface.
 
@@ -527,61 +568,65 @@ def _build_subface_corners(origin, ux, uy, offx, offy, width, height, z0):
         list[Point3D]: Corner points as Point3D objects.
     """
     bl = Point3D(origin[0] + ux * offx, origin[1] + uy * offx, z0 + offy)
-    br = Point3D(origin[0] + ux * (offx + width), origin[1] + uy * (offx + width), z0 + offy)
+    br = Point3D(
+        origin[0] + ux * (offx + width),
+        origin[1] + uy * (offx + width),
+        z0 + offy
+    )
     tr = Point3D(br.x, br.y, z0 + offy + height)
     tl = Point3D(bl.x, bl.y, tr.z)
     return [bl, br, tr, tl]
 
+
 def _verts_to_tuples(verts_dict):
-    """
-    Converts a DOE-2 POLYGON  verts string like:
-        {'V1': '( 0, 0 )', 'V2': '( 10, 0 )', ...}
-    into a list of (x, y) float tuples like:
-        [(0.0, 0.0), (10.0, 0.0), ...]
+    """Convert a DOE-2 POLYGON vertex string into a list of (x, y) float tuples.
+
+    For example, a string like {'V1': '( 0, 0 )', 'V2': '( 10, 0 )', ...}
+    will be converted into a list of tuples like [(0.0, 0.0), (10.0, 0.0), ...]
 
     Args:
-        verts_dict: A dict of vertice labels and points 
+        verts_dict: A dict of vertex labels and points.
 
     Returns:
-        A list of (x, y) tuples as floats
+        A list of (x, y) tuples as floats.
     """
     coord_pat = re.compile(r'\(\s*([-\d.]+)\s*,\s*([-\d.]+)\s*\)')
-    pairs = coord_pat.findall(str(verts_dict))    
+    pairs = coord_pat.findall(str(verts_dict))
     return [(float(x), float(y)) for x, y in pairs]
 
-def child_objects_from_parent(cmd_dict, parent_name, parent_command, child_command):
-    """
-    Given the full dict of parsed INP blocks, and one parent instance,
-    return all of the child_command objects that fall between that
-    parent’s line and its next‐sibling parent’s line.
+
+def _child_objects_from_parent(cmd_dict, parent_name, parent_command, child_command):
+    """Return all child_command objects between a parent's line and its next sibling line.
+
+    This requires the full dict of parsed INP blocks and one parent instance.
 
     Args:
         cmd_dict: Command dictionary containing all DOE2 objects.
-        parent_name: Name of the parent from the objectdict
-        parent_command: The command name of the parent
-        child_command: The command of the child objects to return
+        parent_name: Name of the parent from the object dict.
+        parent_command: The command name of the parent.
+        child_command: The command of the child objects to return.
 
     Returns:
-        Dict[str, dict]:  A mapping of each childs u_name and its data dict
-                         whose __line__ is between the two parent lines.
+        A dictionary with u_name strings for keys and dictionaries for values.
+        This maps each child's u_name to its data dict whose __line__ is between
+        the two parent lines.
     """
-
     # Sort the parents by __line__ just in case
     parents = cmd_dict.get(parent_command, {})
     sorted_parents = sorted(
         parents.items(),
-        key=lambda item: item[1].get("__line__", float("inf"))
+        key=lambda item: item[1].get('__line__', float('inf'))
     )
 
     # Get the start line and end line
     start_line = None
-    end_line = float("inf")
+    end_line = float('inf')
     for idx, (u_name, attrs) in enumerate(sorted_parents):
         if u_name == parent_name:
             start_line = attrs.get("__line__", -1)
             # find the next parents line , this will be the stopping point
             if idx + 1 < len(sorted_parents):
-                end_line = sorted_parents[idx + 1][1].get("__line__", float("inf"))
+                end_line = sorted_parents[idx + 1][1].get('__line__', float('inf'))
             break
 
     # If we cant find the start then return empty dict
@@ -593,12 +638,13 @@ def child_objects_from_parent(cmd_dict, parent_name, parent_command, child_comma
     in_block = {
         c_name: c_data
         for c_name, c_data in children.items()
-        if start_line < c_data.get("__line__", -1) < end_line
+        if start_line < c_data.get('__line__', -1) < end_line
     }
 
     return in_block
 
-def surfaces_from_space(cmd_dict, space_name):
+
+def _surfaces_from_space(cmd_dict, space_name):
     """Return all surface‐type child objects (e.g., walls, roofs) for a given SPACE.
 
     Args:
@@ -606,15 +652,16 @@ def surfaces_from_space(cmd_dict, space_name):
         space_name (str):  Unique name of the SPACE object.
 
     Returns:
-        Dict[str, dict]:  A dictionary mapping each surface U-name to its attributes
-                         for all surfaces under this space.
+        A dictionary mapping each surface U-name to its attributes for all
+        surfaces under this space.
     """
     surf_types = ['EXTERIOR-WALL', 'INTERIOR-WALL', 'UNDERGROUND-WALL', 'ROOF']
     surfs = {}
     for surf in surf_types:
-        children = child_objects_from_parent(cmd_dict, space_name, "SPACE", surf)
+        children = _child_objects_from_parent(cmd_dict, space_name, 'SPACE', surf)
         surfs.update(children)
     return surfs
+
 
 def _calc_azimuth(v1, v2):
     """Calculate the azimuth from point v1 to v2 in degrees clockwise from north.
@@ -630,6 +677,7 @@ def _calc_azimuth(v1, v2):
     ang = math.degrees(math.atan2(dy, dx))
     return ang + 360 if ang < 0 else ang
 
+
 def _get_wall_tilt(w_attrs):
     """Return the wall’s tilt angle in degrees, with overrides for special LOCATIONs.
 
@@ -639,34 +687,36 @@ def _get_wall_tilt(w_attrs):
     Returns:
         float: Tilt angle (0 = horizontal up, 90 = vertical, 180 = horizontal down).
     """
-    loc = (w_attrs.get("LOCATION") or "").upper()
+    loc = (w_attrs.get('LOCATION') or '').upper()
     try:
         tilt = float(w_attrs.get("TILT", 90) or 90)
     except (TypeError, ValueError):
         tilt = 90
-    if loc.startswith("SPACE-V"):
+    if loc.startswith('SPACE-V'):
         return 90
-    if loc == "TOP":
+    if loc == 'TOP':
         return 0
-    if loc == "BOTTOM":
+    if loc == 'BOTTOM':
         return 180
     return tilt
+
 
 def _origin_and_azimuth(obj_attrs, parent_vertices, is_wall):
     """Compute the local origin (x, y, z) and azimuth for a SPACE, WALL, or FLOOR.
 
     Args:
         obj_attrs (dict): Attributes dictionary for the object (SPACE or WALL).
-        parent_vertices (list[tuple[float, float]]): Vertex list of the parent polygon , None for FLOOR.
+        parent_vertices (list[tuple[float, float]]): Vertex list of the parent polygon
+            or None for FLOOR.
 
     Returns:
         tuple: (x, y, z, azimuth)
             x, y, z : float origin coordinates.
             azimuth (float): Azimuth in degrees .
     """
-    loc = (obj_attrs.get("LOCATION") or "").upper()
-    if loc.startswith(("SPACE-V", "FLOOR-V")):
-        idx = int(loc.split("-V", 1)[1]) - 1
+    loc = (obj_attrs.get('LOCATION') or '').upper()
+    if loc.startswith(('SPACE-V', 'FLOOR-V')):
+        idx = int(loc.split('-V', 1)[1]) - 1
         v1 = parent_vertices[idx]
         nxt = 0 if idx + 1 == len(parent_vertices) else idx + 1
         v2 = parent_vertices[nxt]
@@ -675,13 +725,14 @@ def _origin_and_azimuth(obj_attrs, parent_vertices, is_wall):
         az = _calc_azimuth(v1, v2)
     else:
         x, y, z = _get_origin(obj_attrs)
-        az = float(obj_attrs.get("AZIMUTH", 0) or 0)
+        az = float(obj_attrs.get('AZIMUTH', 0) or 0)
         if not is_wall:
-            az = - az # Reverse azimuth for SPACE and FLOOR
+            az = - az  # Reverse azimuth for SPACE and FLOOR
     return x, y, z, az
 
+
 def _space_height(spc_attrs, flr_attrs):
-    """Return the height of a SPACE in feet
+    """Return the height of a SPACE in feet.
 
     Args:
         spc_attrs (dict): Attributes dictionary for the SPACE.
@@ -692,7 +743,7 @@ def _space_height(spc_attrs, flr_attrs):
 
     Raises:
         ValueError: If neither SPACE["HEIGHT"], FLOOR["SPACE-HEIGHT"], nor
-                    FLOOR["FLOOR-HEIGHT"] is provided 
+                    FLOOR["FLOOR-HEIGHT"] is provided.
     """
     def _to_float(val):
         try:
@@ -700,32 +751,32 @@ def _space_height(spc_attrs, flr_attrs):
         except (TypeError, ValueError):
             return None
 
-    h = _to_float(spc_attrs.get("HEIGHT"))
+    h = _to_float(spc_attrs.get('HEIGHT'))
     if h is not None:
         return h
-    h = _to_float(flr_attrs.get("SPACE-HEIGHT"))
+    h = _to_float(flr_attrs.get('SPACE-HEIGHT'))
     if h is not None:
         return h
-    h = _to_float(flr_attrs.get("FLOOR-HEIGHT"))
+    h = _to_float(flr_attrs.get('FLOOR-HEIGHT'))
     if h is not None:
         return h
 
-    raise ValueError(
-        "Cannot determine height for Space: missing 'HEIGHT', 'SPACE-HEIGHT', or 'FLOOR-HEIGHT'."
-    )
+    err_msg = 'Cannot determine height for Space: ' \
+        'missing "HEIGHT", "SPACE-HEIGHT", or "FLOOR-HEIGHT".'
+    raise ValueError(err_msg)
+
 
 def _transform_space_points(local_pts, space_origin, spc_az,
                             floor_origin, flr_az, glob_az):
-    
     """Convert space‐local vertices to global coordinates (feet).
 
     Args:
-        local_pts (list[Point3D]): Vertices in space‐local coords (feet).
-        space_origin (Point3D):   Origin of the space in parent coords.
-        spc_az (float):           Space azimuth in degrees 
-        floor_origin (Point3D):   Origin of the floor in global coords.
-        flr_az (float):           Floor azimuth in degrees 
-        glob_az (float):          Building azimuth in degrees
+        local_pts (list[Point3D]): Vertices in space-local coords (feet).
+        space_origin (Point3D): Origin of the space in parent coords.
+        spc_az (float): Space azimuth in degrees.
+        floor_origin (Point3D): Origin of the floor in global coords.
+        flr_az (float): Floor azimuth in degrees.
+        glob_az (float): Building azimuth in degrees.
 
     Returns:
         list[Point3D]: Transformed vertices in global coords (feet).
@@ -741,7 +792,7 @@ def _transform_space_points(local_pts, space_origin, spc_az,
     # Translate to space origin
     space_vec = Vector3D(space_origin.x, space_origin.y, space_origin.z)
     pts = [p.move(space_vec) for p in local_pts]
-    
+
     # Rotate by floor azimuth
     if abs(flr_az) > DOE2_TOLERANCE:
         ang = math.radians(flr_az)
@@ -755,10 +806,3 @@ def _transform_space_points(local_pts, space_origin, spc_az,
     # Translate to floor origin
     floor_vec = Vector3D(floor_origin.x, floor_origin.y, floor_origin.z)
     return [p.move(floor_vec) for p in pts]
-
-
-
-
-     
-
-

--- a/tests/reader_test.py
+++ b/tests/reader_test.py
@@ -1,7 +1,6 @@
 """Test the reader functions."""
 import os
-from honeybee_doe2.reader import command_dict_from_inp, model_from_inp
-from honeybee.model import Model
+from honeybee_doe2.reader import command_dict_from_inp, model_from_inp_file
 
 
 def test_parse_inp_file():
@@ -10,7 +9,7 @@ def test_parse_inp_file():
     with open(inp_file_path, 'r') as doe_file:
         inp_content = doe_file.read()
     inp_object_dict = command_dict_from_inp(inp_content)
-    
+
     assert isinstance(inp_object_dict, dict)
     assert 'PARAMETER' in inp_object_dict or len(inp_object_dict) > 0
 
@@ -29,9 +28,7 @@ def test_convert_underground_from_wiz():
     """Test converting an underground space from wizard to HBJSON."""
     inp_path = os.path.join(os.path.dirname(__file__), 'assets', 'underground_from_wiz.inp')
     out_path = os.path.join(os.path.dirname(__file__), 'assets', 'out_underground_from_wiz.hbjson')
-    with open(inp_path, 'r') as doe_file:
-        inp_content = doe_file.read()
-    model = model_from_inp(inp_content)
+    model = model_from_inp_file(inp_path)
     model.to_hbjson(out_path)
 
 
@@ -39,9 +36,7 @@ def test_convert_stacked_rect_from_wiz():
     """Test converting stacked rectangular geometry from wizard to HBJSON."""
     inp_path = os.path.join(os.path.dirname(__file__), 'assets', 'stacked_rect_from_wiz.inp')
     out_path = os.path.join(os.path.dirname(__file__), 'assets', 'out_stacked_rect_from_wiz.hbjson')
-    with open(inp_path, 'r') as doe_file:
-        inp_content = doe_file.read()
-    model = model_from_inp(inp_content)
+    model = model_from_inp_file(inp_path)
     model.to_hbjson(out_path)
 
 
@@ -49,9 +44,7 @@ def test_convert_square_from_hbjson():
     """Test converting square geometry from HBJSON back to HBJSON."""
     inp_path = os.path.join(os.path.dirname(__file__), 'assets', 'square_from_hbjson.inp')
     out_path = os.path.join(os.path.dirname(__file__), 'assets', 'out_square_from_hbjson.hbjson')
-    with open(inp_path, 'r') as doe_file:
-        inp_content = doe_file.read()
-    model = model_from_inp(inp_content)
+    model = model_from_inp_file(inp_path)
     model.to_hbjson(out_path)
 
 
@@ -59,9 +52,7 @@ def test_convert_stacked_squa_from_hbjson():
     """Test converting stacked square geometry from HBJSON back to HBJSON."""
     inp_path = os.path.join(os.path.dirname(__file__), 'assets', 'stacked_squa_from_hbjson.inp')
     out_path = os.path.join(os.path.dirname(__file__), 'assets', 'out_stacked_squa_from_hbjson.hbjson')
-    with open(inp_path, 'r') as doe_file:
-        inp_content = doe_file.read()
-    model = model_from_inp(inp_content)
+    model = model_from_inp_file(inp_path)
     model.to_hbjson(out_path)
 
 
@@ -69,18 +60,13 @@ def test_convert_sloped_roof_from_hbjson():
     """Test converting sloped roof geometry from HBJSON back to HBJSON."""
     inp_path = os.path.join(os.path.dirname(__file__), 'assets', 'sloped_roof_from_hbjson.inp')
     out_path = os.path.join(os.path.dirname(__file__), 'assets', 'out_sloped_roof_from_hbjson.hbjson')
-    with open(inp_path, 'r') as doe_file:
-        inp_content = doe_file.read()
-    model = model_from_inp(inp_content)
+    model = model_from_inp_file(inp_path)
     model.to_hbjson(out_path)
+
 
 def test_school_project_from_wiz():
     """Test full school project from wizard to HBJSON."""
     inp_path = os.path.join(os.path.dirname(__file__), 'assets', 'school_project_from_wiz.inp')
     out_path = os.path.join(os.path.dirname(__file__), 'assets', 'out_school_project_from_wiz.hbjson')
-    with open(inp_path, 'r') as doe_file:
-        inp_content = doe_file.read()
-    model = model_from_inp(inp_content)
+    model = model_from_inp_file(inp_path)
     model.to_hbjson(out_path)
-
-


### PR DESCRIPTION
Most of them were extra spaces and line breaks where they should not be. Or places where there was supposed to be an extra line break but there was not.